### PR TITLE
Optimize GeneBe annotation workflow

### DIFF
--- a/annotate_genebe.py
+++ b/annotate_genebe.py
@@ -1,5 +1,6 @@
 # pip install genebe pandas openpyxl
 import os
+import sys
 import pandas as pd
 import genebe as gnb
 
@@ -8,48 +9,74 @@ import genebe as gnb
 
 # …or skip set_credentials and pass them on each call by setting use_netrc=False below.
 
-def annotate_excel_file(input_path, output_path):
-    # Read your sheet
-    df = pd.read_excel(input_path, sheet_name=0, engine='openpyxl')
-    
-    # Build the minimal variant DataFrame
-    df_vars = pd.DataFrame({
-        'chr': df['CHROM'].astype(str).str.replace('chr', '', case=False),
-        'pos': df['POS'].astype(int),
-        'ref': df['REF'].astype(str),
-        'alt': df['ALT'].astype(str),
+def _build_variant_df(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a DataFrame with columns chr,pos,ref,alt from a parsed Excel file."""
+    return pd.DataFrame({
+        "chr": df["CHROM"].astype(str).str.replace("chr", "", case=False),
+        "pos": df["POS"].astype(int),
+        "ref": df["REF"].astype(str),
+        "alt": df["ALT"].astype(str),
     })
-    
-    # Annotate, requesting a DataFrame back
-    annotated_df = gnb.annotate(
-        df_vars,
-        genome='hg19',                   # Match your build
+
+
+def annotate_folder(input_folder: str) -> None:
+    """Annotate all Excel files in ``input_folder`` using a single set of unique
+    variants and write the annotated files sorted by AF into a ``gnb_anno``
+    directory in the parent of ``input_folder``."""
+
+    excel_files = [f for f in os.listdir(input_folder) if f.lower().endswith((".xlsx", ".xls"))]
+    if not excel_files:
+        print("No Excel files found for annotation.")
+        return
+
+    dfs = {}
+    all_var_dfs = []
+
+    # Collect variant rows from each file
+    for fn in excel_files:
+        path = os.path.join(input_folder, fn)
+        df = pd.read_excel(path, sheet_name=0, engine="openpyxl")
+        var_df = _build_variant_df(df)
+        dfs[fn] = (df, var_df)
+        all_var_dfs.append(var_df)
+
+    unique_vars = pd.concat(all_var_dfs, ignore_index=True).drop_duplicates().reset_index(drop=True)
+
+    # Annotate the unique variants via GeneBe
+    annotated_unique = gnb.annotate(
+        unique_vars,
+        genome="hg19",
         use_ensembl=False,
         use_refseq=True,
         flatten_consequences=True,
-        output_format='dataframe',       # <-- ensure a DataFrame is returned
-        use_netrc=False,                 # <-- disable netrc so username/api_key are honored
-        username="tgarg2@jhu.edu",       # optional if you didn’t call set_credentials
+        output_format="dataframe",
+        use_netrc=False,
+        username="tgarg2@jhu.edu",
         api_key="ak-xo8hVORNe1bHu3oqei8PKtxiI",
-        batch_size=500
+        batch_size=500,
     )
-    
-    # Side-by-side concat (same row order) instead of merge
-    merged = pd.concat([df.reset_index(drop=True), annotated_df.reset_index(drop=True)], axis=1)
-    
-    # Write it out
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
-    merged.to_excel(output_path, index=False, engine='openpyxl')
+
+    output_folder = os.path.join(os.path.dirname(os.path.abspath(input_folder)), "gnb_anno")
+    os.makedirs(output_folder, exist_ok=True)
+
+    for fn in excel_files:
+        df, var_df = dfs[fn]
+        annotated_df = var_df.merge(annotated_unique, on=["chr", "pos", "ref", "alt"], how="left")
+        merged = pd.concat(
+            [df.reset_index(drop=True), annotated_df.drop(columns=["chr", "pos", "ref", "alt"]).reset_index(drop=True)],
+            axis=1,
+        )
+        merged.sort_values(by="AF", ascending=False, inplace=True)
+        out_path = os.path.join(output_folder, fn)
+        merged.to_excel(out_path, index=False, engine="openpyxl")
+        print(f"Annotated {fn} → {out_path}")
+
 
 def main():
-    input_folder = '.'
-    output_folder = 'gnb_anno'
-    for fn in os.listdir(input_folder):
-        if fn.lower().endswith(('.xlsx', '.xls')):
-            in_f  = os.path.join(input_folder, fn)
-            out_f = os.path.join(output_folder, fn)
-            annotate_excel_file(in_f, out_f)
-            print(f"Annotated {fn} → {out_f}")
+    folder = os.getcwd()
+    if len(sys.argv) > 1:
+        folder = sys.argv[1]
+    annotate_folder(folder)
 
 if __name__ == '__main__':
     main()

--- a/brca_vcf_parser.py
+++ b/brca_vcf_parser.py
@@ -15,6 +15,8 @@ For each VCF:
    provided folder.
 6. Add a "VCF_COUNT" column showing in how many VCF files the variant occurs as "<count>/<total files>".
 7. Save the final DataFrame to an Excel file in ./<input_folder>/outputExcel/.
+8. Automatically run GeneBe annotation on these Excel files and store the
+   results in a ``gnb_anno`` folder alongside ``outputExcel``.
 
 
 Usage:
@@ -24,6 +26,7 @@ Usage:
 import os
 import sys
 import pandas as pd
+import annotate_genebe
 
 def parse_info(info_str):
     """
@@ -173,6 +176,9 @@ def main():
     for filename in vcf_files:
         vcf_path = os.path.join(folder, filename)
         process_vcf_file(vcf_path, output_dir, variant_counts, len(vcf_files))
+
+    # Automatically annotate the produced Excel files using GeneBe
+    annotate_genebe.annotate_folder(output_dir)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- deduplicate variants before querying GeneBe
- sort annotated output by AF
- store GeneBe results in a `gnb_anno` folder next to `outputExcel`
- automatically run GeneBe annotation after parsing VCFs

## Testing
- `python3 -m py_compile annotate_genebe.py brca_vcf_parser.py`

------
https://chatgpt.com/codex/tasks/task_e_68500f0d39a08327a8c4fec69e3c57f7