### PR TITLE
Fix GeneBe annotation merge

### DIFF
--- a/annotate_genebe.py
+++ b/annotate_genebe.py
@@ -82,7 +82,6 @@ def annotate_folder(input_folder: str) -> None:
     if not local_ann.empty:
         annotated_unique = unique_vars.merge(local_ann, on=merge_cols, how="left")
         to_annotate = annotated_unique[annotated_unique.isna().any(axis=1)][merge_cols]
-        annotated_unique = annotated_unique.dropna(axis=0, subset=local_ann.columns.difference(merge_cols), how="all")
 
     if not to_annotate.empty:
         new_ann = gnb.annotate(


### PR DESCRIPTION
## Summary
- ensure new GeneBe annotations are merged back into the output

## Testing
- `python3 -m py_compile annotate_genebe.py brca_vcf_parser.py`
- `python3 - <<'PY'
import pandas as pd
import annotate_genebe
from unittest.mock import patch
import os, glob
if os.path.exists('annotated_variants.xlsx'): os.remove('annotated_variants.xlsx')
for d in ['gnb_anno']:
    if os.path.isdir(d):
        for f in os.listdir(d): os.remove(os.path.join(d,f))
        os.rmdir(d)
os.makedirs('input3', exist_ok=True)
local_ann = pd.DataFrame({'chr':['1'],'pos':['100'],'ref':['A'],'alt':['T'],'gene':['GENE1'],'FIRST_ANNOTATED':['2021-01-01']})
local_ann.to_excel('annotated_variants.xlsx', index=False)
df = pd.DataFrame({'CHROM':['1','1'],'POS':['100','200'],'REF':['A','G'],'ALT':['T','C'],'AF':[0.1,0.2]})
df.to_excel('input3/test.xlsx', index=False)
new_ann = pd.DataFrame({'chr':['1'],'pos':['200'],'ref':['G'],'alt':['C'],'gene':['GENE2'],'FIRST_ANNOTATED':['2024-01-01']})
def fake_annotate(df, **kwargs):
    print('annotate called for')
    print(df)
    return new_ann
with patch('genebe.annotate', fake_annotate):
    annotate_genebe.annotate_folder('input3')
print(pd.read_excel('gnb_anno/test.xlsx'))
PY

------
https://chatgpt.com/codex/tasks/task_e_686651e7e7fc8327bfe976044f25e1b3